### PR TITLE
REST API endpoints rework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,12 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.12.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>RELEASE</version>
+            <scope>compile</scope>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/com/sda/eventapp/configuration/SecurityConfig.java
+++ b/src/main/java/com/sda/eventapp/configuration/SecurityConfig.java
@@ -19,6 +19,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests(requests -> requests
                         .requestMatchers("/", "/home",
+                                "/api/v1/events",
                                 "/user/register",
                                 "/detail-view/**",
                                 "/css/**", "/js/**", "/assets/**", "/images/**")

--- a/src/main/java/com/sda/eventapp/dto/EventApi.java
+++ b/src/main/java/com/sda/eventapp/dto/EventApi.java
@@ -1,11 +1,15 @@
 package com.sda.eventapp.dto;
 
 import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.Set;
 
 @Builder
+@Getter
+@Setter
 public class EventApi {
     private Long id;
     private String title;

--- a/src/main/java/com/sda/eventapp/dto/EventApi.java
+++ b/src/main/java/com/sda/eventapp/dto/EventApi.java
@@ -12,6 +12,7 @@ public class EventApi {
     private String description;
     private LocalDateTime startingDateTime;
     private LocalDateTime endingDateTime;
+    private String imageUrl; // If not on localhost this would be real imageUrl
     private Set<String> attenders;
     private String ownerNickname;
 }

--- a/src/main/java/com/sda/eventapp/dto/EventApi.java
+++ b/src/main/java/com/sda/eventapp/dto/EventApi.java
@@ -1,6 +1,5 @@
 package com.sda.eventapp.dto;
 
-import com.sda.eventapp.model.Image;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -13,7 +12,6 @@ public class EventApi {
     private String description;
     private LocalDateTime startingDateTime;
     private LocalDateTime endingDateTime;
-    private Image image;
     private Set<String> attenders;
     private String ownerNickname;
 }

--- a/src/main/java/com/sda/eventapp/dto/EventApi.java
+++ b/src/main/java/com/sda/eventapp/dto/EventApi.java
@@ -1,0 +1,19 @@
+package com.sda.eventapp.dto;
+
+import com.sda.eventapp.model.Image;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@Builder
+public class EventApi {
+    private Long id;
+    private String title;
+    private String description;
+    private LocalDateTime startingDateTime;
+    private LocalDateTime endingDateTime;
+    private Image image;
+    private Set<String> attenders;
+    private String ownerNickname;
+}

--- a/src/main/java/com/sda/eventapp/dto/EventApiWrapper.java
+++ b/src/main/java/com/sda/eventapp/dto/EventApiWrapper.java
@@ -1,0 +1,10 @@
+package com.sda.eventapp.dto;
+
+import lombok.AllArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor
+public class EventApiWrapper {
+    private List<EventApi> eventApiList;
+}

--- a/src/main/java/com/sda/eventapp/dto/EventApiWrapper.java
+++ b/src/main/java/com/sda/eventapp/dto/EventApiWrapper.java
@@ -1,9 +1,13 @@
 package com.sda.eventapp.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
 
+@Getter
+@Setter
 @AllArgsConstructor
 public class EventApiWrapper {
     private List<EventApi> eventApiList;

--- a/src/main/java/com/sda/eventapp/dto/EventView.java
+++ b/src/main/java/com/sda/eventapp/dto/EventView.java
@@ -1,6 +1,5 @@
 package com.sda.eventapp.dto;
 
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.sda.eventapp.model.Image;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,9 +23,7 @@ public class EventView {
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private LocalDateTime endingDateTime;
 
-    @JsonManagedReference
     private Image image;
-
     private Set<String> usersNicknames;
     private String ownerNickname;
 }

--- a/src/main/java/com/sda/eventapp/dto/EventView.java
+++ b/src/main/java/com/sda/eventapp/dto/EventView.java
@@ -1,5 +1,6 @@
 package com.sda.eventapp.dto;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.sda.eventapp.model.Image;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,11 +17,16 @@ public class EventView {
     private long id;
     private String title;
     private String description;
+
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private LocalDateTime startingDateTime;
+
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private LocalDateTime endingDateTime;
+
+    @JsonManagedReference
     private Image image;
+
     private Set<String> usersNicknames;
     private String ownerNickname;
 }

--- a/src/main/java/com/sda/eventapp/mapper/EventMapper.java
+++ b/src/main/java/com/sda/eventapp/mapper/EventMapper.java
@@ -63,6 +63,7 @@ public class EventMapper {
                         .description(event.getDescription())
                         .startingDateTime(event.getStartingDateTime())
                         .endingDateTime(event.getEndingDateTime())
+                        .imageUrl(event.getImage().getPath() + event.getImage().getFilename())
                         .attenders(getUsersNicknames(event))
                         .ownerNickname(getOwnerNickname(event))
                         .build())

--- a/src/main/java/com/sda/eventapp/mapper/EventMapper.java
+++ b/src/main/java/com/sda/eventapp/mapper/EventMapper.java
@@ -1,12 +1,15 @@
 package com.sda.eventapp.mapper;
 
+import com.sda.eventapp.dto.EventApi;
 import com.sda.eventapp.dto.EventView;
 import com.sda.eventapp.model.Event;
 import com.sda.eventapp.model.User;
 import com.sda.eventapp.web.mvc.form.EventForm;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Component
@@ -59,5 +62,30 @@ public class EventMapper {
     public EventView[] toEventViewArray(List<Event> events) {
         List<EventView> eventViews = this.toEventViewList(events);
         return eventViews.toArray(new EventView[0]);
+    }
+
+    public List<EventApi> toEventApiList(List<Event> events) {
+        return events.stream()
+                .map(event -> EventApi.builder()
+                        .id(event.getId())
+                        .title(event.getTitle())
+                        .description(event.getDescription())
+                        .startingDateTime(event.getStartingDateTime())
+                        .endingDateTime(event.getEndingDateTime())
+                        .image(event.getImage())
+                        .attenders(getUsersNicknames(event))
+                        .ownerNickname(getOwnerNickname(event))
+                        .build())
+                .toList();
+    }
+
+    private Set<String> getUsersNicknames(@NotNull Event event) {
+        return event.getUsers().stream()
+                .map(User::getUsername)
+                .collect(Collectors.toSet());
+    }
+
+    private String getOwnerNickname(@NotNull Event event) {
+        return event.getOwner().getUsername();
     }
 }

--- a/src/main/java/com/sda/eventapp/mapper/EventMapper.java
+++ b/src/main/java/com/sda/eventapp/mapper/EventMapper.java
@@ -55,4 +55,9 @@ public class EventMapper {
                 .owner(form.getOwner())
                 .build();
     }
+
+    public EventView[] toEventViewArray(List<Event> events) {
+        List<EventView> eventViews = this.toEventViewList(events);
+        return eventViews.toArray(new EventView[0]);
+    }
 }

--- a/src/main/java/com/sda/eventapp/mapper/EventMapper.java
+++ b/src/main/java/com/sda/eventapp/mapper/EventMapper.java
@@ -68,7 +68,6 @@ public class EventMapper {
                         .description(event.getDescription())
                         .startingDateTime(event.getStartingDateTime())
                         .endingDateTime(event.getEndingDateTime())
-                        .image(event.getImage())
                         .attenders(getUsersNicknames(event))
                         .ownerNickname(getOwnerNickname(event))
                         .build())

--- a/src/main/java/com/sda/eventapp/mapper/EventMapper.java
+++ b/src/main/java/com/sda/eventapp/mapper/EventMapper.java
@@ -24,10 +24,8 @@ public class EventMapper {
                         .startingDateTime(event.getStartingDateTime())
                         .endingDateTime(event.getEndingDateTime())
                         .image(event.getImage())
-                        .usersNicknames(event.getUsers().stream()
-                                .map(User::getUsername)
-                                .collect(Collectors.toSet()))
-                        .ownerNickname(event.getOwner().getUsername())
+                        .usersNicknames(getUsersNicknames(event))
+                        .ownerNickname(getOwnerNickname(event))
                         .build())
                 .toList();
     }
@@ -40,10 +38,8 @@ public class EventMapper {
                 .startingDateTime(event.getStartingDateTime())
                 .endingDateTime(event.getEndingDateTime())
                 .image(event.getImage())
-                .usersNicknames(event.getUsers().stream()
-                        .map(User::getUsername)
-                        .collect(Collectors.toSet()))
-                .ownerNickname(event.getOwner().getUsername())
+                .usersNicknames(getUsersNicknames(event))
+                .ownerNickname(getOwnerNickname(event))
                 .build();
     }
 

--- a/src/main/java/com/sda/eventapp/mapper/EventMapper.java
+++ b/src/main/java/com/sda/eventapp/mapper/EventMapper.java
@@ -55,11 +55,6 @@ public class EventMapper {
                 .build();
     }
 
-    public EventView[] toEventViewArray(List<Event> events) {
-        List<EventView> eventViews = this.toEventViewList(events);
-        return eventViews.toArray(new EventView[0]);
-    }
-
     public List<EventApi> toEventApiList(List<Event> events) {
         return events.stream()
                 .map(event -> EventApi.builder()

--- a/src/main/java/com/sda/eventapp/model/Image.java
+++ b/src/main/java/com/sda/eventapp/model/Image.java
@@ -1,5 +1,6 @@
 package com.sda.eventapp.model;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -10,15 +11,14 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class Image {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String filename;
-
     private String path;
 
+    @JsonBackReference
     @OneToOne(mappedBy = "image")
     private Event event;
 }

--- a/src/main/java/com/sda/eventapp/model/Image.java
+++ b/src/main/java/com/sda/eventapp/model/Image.java
@@ -1,6 +1,5 @@
 package com.sda.eventapp.model;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -18,7 +17,6 @@ public class Image {
     private String filename;
     private String path;
 
-    @JsonBackReference
     @OneToOne(mappedBy = "image")
     private Event event;
 }

--- a/src/main/java/com/sda/eventapp/service/EventService.java
+++ b/src/main/java/com/sda/eventapp/service/EventService.java
@@ -148,8 +148,11 @@ public class EventService {
         }
     }
 
-    public List<EventView> findEventViewsByDateRange(LocalDateTime start, LocalDateTime end) {
-        return mapper.toEventViewList(repository.findAllEventByDateRange(start, end));
+    public EventApiWrapper findEventViewsByDateRange(LocalDateTime start, LocalDateTime end) {
+        return new EventApiWrapper(
+                mapper.toEventApiList(
+                        repository.findAllEventByDateRange(start, end))
+        );
     }
 
     public List<CommentView> findCommentViewsByEventId(Long eventId) {

--- a/src/main/java/com/sda/eventapp/service/EventService.java
+++ b/src/main/java/com/sda/eventapp/service/EventService.java
@@ -148,7 +148,7 @@ public class EventService {
         }
     }
 
-    public EventApiWrapper findEventViewsByDateRange(LocalDateTime start, LocalDateTime end) {
+    public EventApiWrapper getEventApiWrapperWithEventsInDateRange(LocalDateTime start, LocalDateTime end) {
         return new EventApiWrapper(
                 mapper.toEventApiList(
                         repository.findAllEventByDateRange(start, end))

--- a/src/main/java/com/sda/eventapp/service/EventService.java
+++ b/src/main/java/com/sda/eventapp/service/EventService.java
@@ -321,7 +321,7 @@ public class EventService {
         }
     }
 
-    public EventApiWrapper findAllFutureEventViewsWrapped() {
+    public EventApiWrapper getEventApiWrapperWithAllFutureEvents() {
         return new EventApiWrapper(
                 mapper.toEventApiList(
                         repository.findAllFutureEvents()

--- a/src/main/java/com/sda/eventapp/service/EventService.java
+++ b/src/main/java/com/sda/eventapp/service/EventService.java
@@ -1,6 +1,7 @@
 package com.sda.eventapp.service;
 
 import com.sda.eventapp.dto.CommentView;
+import com.sda.eventapp.dto.EventApiWrapper;
 import com.sda.eventapp.dto.EventView;
 import com.sda.eventapp.mapper.EventMapper;
 import com.sda.eventapp.model.Event;
@@ -137,10 +138,6 @@ public class EventService {
 
     public EventView findEventViewById(Long id) {
         return mapper.toEventView(this.findById(id));
-    }
-
-    public EventView[] findAllEventViewsArray() {
-        return mapper.toEventViewArray(repository.findAll());
     }
 
     public List<EventView> findAllEventViews(String title, boolean futureEventsFilter, boolean ongoingEventsFilter, boolean pastEventsFilter) {
@@ -322,5 +319,13 @@ public class EventService {
         else {
             return mapper.toEventViewList(repository.findOwnedAndAttendedAllEventsById(userId));
         }
+    }
+
+    public EventApiWrapper findAllFutureEventViewsWrapped() {
+        return new EventApiWrapper(
+                mapper.toEventApiList(
+                        repository.findAllFutureEvents()
+                )
+        );
     }
 }

--- a/src/main/java/com/sda/eventapp/service/EventService.java
+++ b/src/main/java/com/sda/eventapp/service/EventService.java
@@ -139,8 +139,8 @@ public class EventService {
         return mapper.toEventView(this.findById(id));
     }
 
-    public List<EventView> findAllEventViews() {
-        return mapper.toEventViewList(repository.findAll());
+    public EventView[] findAllEventViewsArray() {
+        return mapper.toEventViewArray(repository.findAll());
     }
 
     public List<EventView> findAllEventViews(String title, boolean futureEventsFilter, boolean ongoingEventsFilter, boolean pastEventsFilter) {

--- a/src/main/java/com/sda/eventapp/web/rest/controller/EventRestController.java
+++ b/src/main/java/com/sda/eventapp/web/rest/controller/EventRestController.java
@@ -25,6 +25,6 @@ public class EventRestController {
 
     @GetMapping(params = {"start", "end"})
     public EventApiWrapper getEventsInDateRange(@RequestParam("start") LocalDateTime start, @RequestParam("end") LocalDateTime end) {
-        return eventService.findEventViewsByDateRange(start, end);
+        return eventService.getEventApiWrapperWithEventsInDateRange(start, end);
     }
 }

--- a/src/main/java/com/sda/eventapp/web/rest/controller/EventRestController.java
+++ b/src/main/java/com/sda/eventapp/web/rest/controller/EventRestController.java
@@ -1,7 +1,6 @@
 package com.sda.eventapp.web.rest.controller;
 
 import com.sda.eventapp.dto.EventApiWrapper;
-import com.sda.eventapp.dto.EventView;
 import com.sda.eventapp.service.EventService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,7 +10,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Slf4j
 @RestController
@@ -20,13 +18,13 @@ import java.util.List;
 public class EventRestController {
     private final EventService eventService;
 
-    @GetMapping()
+    @GetMapping
     public EventApiWrapper getAllFutureEvents() {
         return eventService.getEventApiWrapperWithAllFutureEvents();
     }
 
-    @GetMapping("/date")
-    public List<EventView> getEventViewsByDateRange(@RequestParam LocalDateTime start, @RequestParam LocalDateTime end) {
+    @GetMapping(params = {"start", "end"})
+    public EventApiWrapper getEventsInDateRange(@RequestParam("start") LocalDateTime start, @RequestParam("end") LocalDateTime end) {
         return eventService.findEventViewsByDateRange(start, end);
     }
 }

--- a/src/main/java/com/sda/eventapp/web/rest/controller/EventRestController.java
+++ b/src/main/java/com/sda/eventapp/web/rest/controller/EventRestController.java
@@ -22,7 +22,7 @@ public class EventRestController {
 
     @GetMapping()
     public EventApiWrapper getAllFutureEvents() {
-        return eventService.findAllFutureEventViewsWrapped();
+        return eventService.getEventApiWrapperWithAllFutureEvents();
     }
 
     @GetMapping("/date")

--- a/src/main/java/com/sda/eventapp/web/rest/controller/EventRestController.java
+++ b/src/main/java/com/sda/eventapp/web/rest/controller/EventRestController.java
@@ -19,9 +19,9 @@ import java.util.List;
 public class EventRestController {
     private final EventService eventService;
 
-    @GetMapping("/all")
-    public List<EventView> getEventViews() {
-        return eventService.findAllEventViews();
+    @GetMapping()
+    public EventView[] getEventViews() {
+        return eventService.findAllEventViewsArray();
     }
 
     @GetMapping("/date")

--- a/src/main/java/com/sda/eventapp/web/rest/controller/EventRestController.java
+++ b/src/main/java/com/sda/eventapp/web/rest/controller/EventRestController.java
@@ -1,5 +1,6 @@
 package com.sda.eventapp.web.rest.controller;
 
+import com.sda.eventapp.dto.EventApiWrapper;
 import com.sda.eventapp.dto.EventView;
 import com.sda.eventapp.service.EventService;
 import lombok.RequiredArgsConstructor;
@@ -20,8 +21,8 @@ public class EventRestController {
     private final EventService eventService;
 
     @GetMapping()
-    public EventView[] getEventViews() {
-        return eventService.findAllEventViewsArray();
+    public EventApiWrapper getAllFutureEvents() {
+        return eventService.findAllFutureEventViewsWrapped();
     }
 
     @GetMapping("/date")

--- a/src/main/java/com/sda/eventapp/web/rest/controller/EventRestController.java
+++ b/src/main/java/com/sda/eventapp/web/rest/controller/EventRestController.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 @Slf4j
 @RestController
-@RequestMapping("/event")
+@RequestMapping("/api/v1/events")
 @RequiredArgsConstructor
 public class EventRestController {
     private final EventService eventService;


### PR DESCRIPTION
# Changes
### New feature changes:
- Added `EventApiWrapper`. It contains one field `List<EventApi>`.
- Added `EventApi`. A DTO that is then send as List via endpoint inside of `EventApiWrapper`.
- Reworked `EventRestController`. It's now returning `EventApiWrapper`.
- Added method to `EventMapper` to change `List<Event>` into `List<EventApi>` needed for `EventApiWrapper`.

### Service layer changes:
- Removed unused method `findAllEventViews()`
- Changed method `public List<EventView> findEventViewsByDateRange` to `public EventApiWrapper getEventApiWrapperWithEventsInDateRange`
- Added method `public EventApiWrapper getEventApiWrapperWithAllFutureEvents()`

### General changes:
- Added dependency for `@NotNull` annotation.
- Added path to events API to be accessed by everyone.
- Reworked `EventMapper`. Removed boilerplate code as there were parts that were repeated.

## Things to consider
`EventApiWrapper` might not need `imageUrl` if we don't implement it on the client side.

## Notes
I wanted to make changes to the image handling. I tried to send it into the imgur.com and save it here but there was a problem. We are working on local machines and app won't be on any web server, so couldn't make redirect from imgur after authorization back to local machine (needed special program which then would be required on every machine that would ran it).

What then I tried was to send images by REST endpoint directly with one of the field in the `EventApi` be like `byte[] imageStream` but this can go wrong pretty quick, as we can have files up to 10 MB in size and there can be a lot of events. So we have to send a path/URL.
