### PR TITLE
Rework of saving image

### DIFF
--- a/src/main/java/com/sda/eventapp/model/Image.java
+++ b/src/main/java/com/sda/eventapp/model/Image.java
@@ -17,8 +17,6 @@ public class Image {
 
     private String filename;
 
-    private String path;
-
     @OneToOne(mappedBy = "image")
     private Event event;
 }

--- a/src/main/java/com/sda/eventapp/service/ImageService.java
+++ b/src/main/java/com/sda/eventapp/service/ImageService.java
@@ -1,38 +1,38 @@
 package com.sda.eventapp.service;
 
 import com.sda.eventapp.model.Image;
-import com.sda.eventapp.repository.ImageRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FilenameUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.UUID;
 import java.util.stream.IntStream;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ImageService {
-    private final ImageRepository repository;
+    private final static Path ABS_PATH = Paths.get("").toAbsolutePath();
+    private final static Path IMAGES_PATH = Path.of("src", "main", "resources", "static", "images");
+    private final static String DEFAULT_IMAGE_NAME = "default-event-image.jpeg";
 
-    public boolean existsByFilename(String filename) {
-        return repository.existsByFilename(filename);
+    private Image buildImage() {
+        return buildImage(DEFAULT_IMAGE_NAME);
     }
 
-    public Image buildDefaultImage(Path absolutePath, String contentRootPath) {
-        return Image.builder()
-                .filename("default-event-image.jpeg")
-                .path(absolutePath + "/" + contentRootPath)
-                .build();
-    }
-
-    public Image buildImage(String name, Path absolutePath, String contentRootPath) {
+    private Image buildImage(String name) {
         return Image.builder()
                 .filename(name)
-                .path(absolutePath + "/" + contentRootPath)
                 .build();
     }
 
@@ -56,6 +56,69 @@ public class ImageService {
                 .mapToObj(i -> extensions[i] + (i < extensions.length - 1 ? ", " : ""))
                 .forEach(messageSB::append);
         return messageSB.toString();
+    }
+
+    /**
+     * Creates directory named after path: {@link com.sda.eventapp.service.ImageService#IMAGES_PATH} if it doesn't already exist.
+     *
+     * @return true in the same manner as {@link java.io.File#mkdirs()}
+     */
+    private boolean createImageDirectory() {
+        return new File(IMAGES_PATH.toString()).mkdirs();
+    }
+
+    /**
+     * Taking {@link org.springframework.web.multipart.MultipartFile} and checks its name if it's {@link java.lang.String#isBlank()} or null.
+     * <br>
+     * If false, it does {@link com.sda.eventapp.service.ImageService#saveImageLocally(MultipartFile)}
+     *
+     * @param file should be checked before if its of required file extension
+     * @return {@link com.sda.eventapp.model.Image} build from {@link org.springframework.web.multipart.MultipartFile}
+     */
+    public Image solveImage(MultipartFile file) {
+        Image image;
+        if (file.getOriginalFilename() == null || file.getOriginalFilename().isBlank()) {
+            image = buildImage();
+        } else {
+            image = saveImageLocally(file);
+        }
+        return image;
+    }
+
+    /**
+     * Creates directory in default location ->  {@link ImageService#createImageDirectory()}.
+     * <br>
+     * Changes filename by adding suffix of {@link LocalDateTime#now()} and {@link UUID#randomUUID()}.
+     * Replacing all ':' and changing these into '-' via {@link String#replaceAll(String regex, String replacement)}
+     * <br>
+     * Then builds image with new filename -> {@link ImageService#buildImage(String fileName)}
+     * <br>
+     *
+     * @param file {@link org.springframework.web.multipart.MultipartFile} that is meant to be saved
+     *             locally and built {@link com.sda.eventapp.model.Image} out of it
+     * @return built and saved locally {@link com.sda.eventapp.model.Image}
+     */
+    private Image saveImageLocally(MultipartFile file) {
+        if (createImageDirectory()) {
+            log.debug("Directory created");
+        }
+
+        String filename = (LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                + UUID.randomUUID()
+                + file.getOriginalFilename())
+                .replaceAll(":", "-");
+
+        Image image = buildImage(filename);
+
+        Path fullPath = Path.of(ABS_PATH.toString(), IMAGES_PATH.toString(), image.getFilename());
+
+        try {
+            byte[] bytes = file.getBytes();
+            Files.write(fullPath, bytes);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return image;
     }
 
     private enum AllowedExtensions {

--- a/src/test/java/com/sda/eventapp/web/mvc/controller/EventControllerTest.java
+++ b/src/test/java/com/sda/eventapp/web/mvc/controller/EventControllerTest.java
@@ -3,14 +3,12 @@ package com.sda.eventapp.web.mvc.controller;
 import com.sda.eventapp.configuration.SecurityConfig;
 import com.sda.eventapp.dto.EventView;
 import com.sda.eventapp.model.Event;
-import com.sda.eventapp.model.Image;
 import com.sda.eventapp.model.User;
 import com.sda.eventapp.repository.EventRepository;
 import com.sda.eventapp.repository.ImageRepository;
 import com.sda.eventapp.repository.UserRepository;
 import com.sda.eventapp.service.EventService;
 import com.sda.eventapp.service.ImageService;
-import com.sda.eventapp.web.mvc.form.CreateUserForm;
 import com.sda.eventapp.web.mvc.form.EventForm;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
@@ -28,9 +26,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -528,9 +524,7 @@ class EventControllerTest {
                     .startingDateTime(LocalDateTime.now().plusDays(7))
                     .endingDateTime(LocalDateTime.now().plusDays(14))
                     .owner(testUser1)
-                    .image(imageService.buildDefaultImage(
-                            Paths.get("").toAbsolutePath(),
-                            "src/main/resources/static/images/"))
+                    .image(imageService.solveImage(new MockMultipartFile("testImage.jpg", "test".getBytes())))
                     .build();
         }
 
@@ -575,7 +569,6 @@ class EventControllerTest {
                                     .orElseThrow(() -> new RuntimeException(EXCEPTION_MESSAGE)))))
                     .andExpect(status().isForbidden())
                     .andExpect(status().reason("ACCESS DENIED - ONLY OWNER CAN UPDATE THIS EVENT"));
-            ;
         }
 
         @Test
@@ -590,7 +583,6 @@ class EventControllerTest {
                                     .orElseThrow(() -> new RuntimeException(EXCEPTION_MESSAGE)))))
                     .andExpect(status().isBadRequest())
                     .andExpect(status().reason("ACCESS DENIED - CANNOT UPDATE AN EVENT AFTER ITS START DATE"));
-            ;
         }
 
         @Test


### PR DESCRIPTION
# Changes

- Removed `path` field from `Image` class. It wasn't needed and was unnecessary being saved to the database
- Moved logic from `EventService` to `ImageService` class
- Added constants of paths and made them safe for any OS
- Adjusted method `buildImage` as there is no longer `path` field
- Method `saveImageLocally` has been adjusted. It's now adding suffix to the filename consisted of `LocalDateTime` in ISO format and `UUID` so it won't repeat