### PR TITLE
Admin account

### DIFF
--- a/src/main/java/com/sda/eventapp/model/User.java
+++ b/src/main/java/com/sda/eventapp/model/User.java
@@ -3,10 +3,8 @@ package com.sda.eventapp.model;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -28,6 +26,9 @@ public class User implements UserDetails {
 
     private String email;
 
+    @Transient
+    private Set<GrantedAuthority> authorities;
+
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
     private Set<Comment> comments;
 
@@ -48,11 +49,6 @@ public class User implements UserDetails {
     @Override
     public int hashCode() {
         return Objects.hash(id);
-    }
-
-    @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        return new HashSet<>(Set.of(new SimpleGrantedAuthority("ROLE_USER")));
     }
 
     @Override

--- a/src/main/java/com/sda/eventapp/service/AdminAccountCreator.java
+++ b/src/main/java/com/sda/eventapp/service/AdminAccountCreator.java
@@ -1,0 +1,37 @@
+package com.sda.eventapp.service;
+
+import com.sda.eventapp.model.User;
+import com.sda.eventapp.repository.UserRepository;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+
+@Service
+public class AdminAccountCreator {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Value("${admin.email}")
+    private String adminEmail;
+    @Value("${admin.password}")
+    private String adminPassword;
+
+    public AdminAccountCreator(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @PostConstruct
+    public void createAdminAccount() {
+        // check if admin account already exists
+        if (!userRepository.existsByEmail(adminEmail)) {
+            // create new admin user
+            User admin = new User();
+            admin.setUsername(adminEmail);
+            admin.setPassword(passwordEncoder.encode(adminPassword));
+            userRepository.save(admin);
+        }
+    }
+}

--- a/src/main/java/com/sda/eventapp/service/AdminAccountCreator.java
+++ b/src/main/java/com/sda/eventapp/service/AdminAccountCreator.java
@@ -29,8 +29,9 @@ public class AdminAccountCreator {
         if (!userRepository.existsByEmail(adminEmail)) {
             // create new admin user
             User admin = new User();
-            admin.setUsername(adminEmail);
+            admin.setEmail(adminEmail);
             admin.setPassword(passwordEncoder.encode(adminPassword));
+            admin.setUsername("Admin");
             userRepository.save(admin);
         }
     }

--- a/src/main/java/com/sda/eventapp/service/AppUserDetailsService.java
+++ b/src/main/java/com/sda/eventapp/service/AppUserDetailsService.java
@@ -1,19 +1,36 @@
 package com.sda.eventapp.service;
 
+import com.sda.eventapp.model.User;
 import com.sda.eventapp.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+import java.util.HashSet;
+import java.util.Set;
+
 @Service
 @RequiredArgsConstructor
 public class AppUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
+    @Value("${admin.email}")
+    private String adminEmail;
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        return userRepository.findByEmail(email).orElseThrow(() -> new UsernameNotFoundException("User with email: \"" + email + "\" not found"));
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new UsernameNotFoundException("User with email: \"" + email + "\" not found"));
+        Set<GrantedAuthority> authorities = new HashSet<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+        // If user has an admin email add them "ROLE_ADMIN"
+        if (user.getEmail().equals(adminEmail)) {
+            authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+        }
+        user.setAuthorities(authorities);
+        return user;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,3 +23,8 @@ spring.servlet.multipart.max-request-size=10MB
 spring.web.resources.static-locations[0]=file:src/main/resources/static/
 spring.web.resources.static-locations[1]=classpath:/static/
 server.tomcat.max-swallow-size=30MB
+#######################
+## ADMIN CREDENTIALS ##
+#######################
+admin.email=admin@eventapp.com
+admin.password=password


### PR DESCRIPTION
# Changes

- Added password and email of an admin account to the `application.properties`
- Added `AdminAccountCreator` in the service layer which is responsible for checking if the admin account is created in the database. If it isn't it will create new one with data provided in `application.properties` and save it to db.
- Added new field `Set<GrantedAuthority> authorities` on the `User` class and removed the getter for it. The getter is now handled via lombok and returns `authorities`. Those are now correctly set in the `loadUserByUsername(String email)` in `AppUserDetailsService` class. More information below.
- Reworked `AppUserDetailsService` and its only method `loadUserByUsername(String email)`. The method now will load user that is in the database as before but on this level now we are setting authorities (aka roles). Every `User` object now will have authority named `"ROLE_USER"`. The next step is to determine whether or not user is an admin so we're checking user email. If it is the same as in the `application.properties` it'll grant them second authority named `"ROLE_ADMIN"`.

### Notes
To be tested on some of the views