### PR TITLE
fix/frontend/delete-profile-dropdown-item-from-navbar

### DIFF
--- a/src/main/resources/templates/create-event.html
+++ b/src/main/resources/templates/create-event.html
@@ -108,12 +108,6 @@
                         class="dropdown-menu dropdown-menu-end">
                         <li>
                             <a class="dropdown-item"
-                               th:href="@{/profile}">
-                                Profile
-                            </a>
-                        </li>
-                        <li>
-                            <a class="dropdown-item"
                                th:href="@{/my-events}">
                                 My Events
                             </a>

--- a/src/main/resources/templates/event-detail-view.html
+++ b/src/main/resources/templates/event-detail-view.html
@@ -108,12 +108,6 @@
                     class="dropdown-menu dropdown-menu-end">
                     <li>
                         <a class="dropdown-item"
-                           th:href="@{/profile}">
-                            Profile
-                        </a>
-                    </li>
-                    <li>
-                        <a class="dropdown-item"
                            th:href="@{/my-events}">
                             My Events
                         </a>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -107,12 +107,6 @@
                         class="dropdown-menu dropdown-menu-end">
                         <li>
                             <a class="dropdown-item"
-                               th:href="@{/profile}">
-                                Profile
-                            </a>
-                        </li>
-                        <li>
-                            <a class="dropdown-item"
                                th:href="@{/my-events}">
                                 My Events
                             </a>

--- a/src/main/resources/templates/my-events-view.html
+++ b/src/main/resources/templates/my-events-view.html
@@ -76,12 +76,6 @@
                         class="dropdown-menu dropdown-menu-end">
                         <li>
                             <a class="dropdown-item"
-                               th:href="@{/profile}">
-                                Profile
-                            </a>
-                        </li>
-                        <li>
-                            <a class="dropdown-item"
                                th:href="@{/my-events}">
                                 My Events
                             </a>

--- a/src/main/resources/templates/update-event.html
+++ b/src/main/resources/templates/update-event.html
@@ -108,12 +108,6 @@
                         class="dropdown-menu dropdown-menu-end">
                         <li>
                             <a class="dropdown-item"
-                               th:href="@{/profile}">
-                                Profile
-                            </a>
-                        </li>
-                        <li>
-                            <a class="dropdown-item"
                                th:href="@{/my-events}">
                                 My Events
                             </a>


### PR DESCRIPTION
Deleted Profile item from dropdown menu in navbar: create-event, event-detail-view, index, my-events-view, update-event