### PR TITLE
Universal card height fix on homepage

### DIFF
--- a/src/main/resources/static/css/index.css
+++ b/src/main/resources/static/css/index.css
@@ -3,3 +3,12 @@
     background-position: center center;
     background-size: cover;
 }
+
+.img-card-cover-fit {
+    object-fit: cover;
+!important;
+    max-height: 12rem;
+!important;
+    width: 100%;
+!important;
+}

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -145,7 +145,7 @@
                     <div class="col-md">
                         <div class="card h-100 h6">
                             <img alt="..."
-                                 class="card-img-top"
+                                 class="card-img-top img-card-cover-fit"
                                  th:object="${event.image}"
                                  th:src="@{${'/images/' + event.image.filename}}"/>
                             <div class="card-body">


### PR DESCRIPTION
# Changes

Cards on the homepage are now universally sized.

- Added `.img-card-cover-fit` css class
- implemented this class on the `index.html`